### PR TITLE
Making a valid gemspec for bundler installs from github by re-using existing markdown README for rdoc.

### DIFF
--- a/smithy.gemspec
+++ b/smithy.gemspec
@@ -13,8 +13,10 @@ Gem::Specification.new do |s|
   s.summary     = "A good CMS written in Rails."
   s.description = "Better than the rest."
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
-
+  s.extra_rdoc_files = ["README.md"]
+  s.rdoc_options = ["--main"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
+  
   s.add_dependency 'rails', '~> 3.2.11'
   s.add_dependency 'jquery-rails'
 
@@ -57,4 +59,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'spork'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'quiet_assets'
+  s.extra_rdoc_files = [ "README.md" ]
 end


### PR DESCRIPTION
Saw the open sourcing in my feed! Congrats. I am taking a kick at the can with it and I fixed a little bundler error I got:

```
smithy at /Users/jody/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/bundler/gems/smithy-677ced904db4 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.rdoc"] are not files
```
